### PR TITLE
🔧 Fixed the build error

### DIFF
--- a/client/src/components/AuthenticatedNavbarComponent.vue
+++ b/client/src/components/AuthenticatedNavbarComponent.vue
@@ -84,6 +84,7 @@ export default {
   data() {
     return {
       searchQuery: "",
+      dashboard: "/dashboard",
     };
   },
   methods: {
@@ -100,8 +101,12 @@ export default {
       }
     },
     redirectDashboard() {
-      this.$router.push("/dashboard");
+      this.$router.push(this.dashboard);
     },
+  },
+  async mounted() {
+    const isAdmin = await this.authStore.isAdmin();
+    this.dashboard = isAdmin ? "/admin-dashboard" : "/dashboard";
   },
 };
 </script>

--- a/client/src/pages/Dashboard/AdminDashboard.vue
+++ b/client/src/pages/Dashboard/AdminDashboard.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <navbar />
+  </div>
+</template>
+
+<script>
+// Components
+import AuthenticatedNavbarComponent from "@/components/AuthenticatedNavbarComponent.vue";
+
+export default {
+  name: "Admin Dashboard",
+  components: {
+    navbar: AuthenticatedNavbarComponent,
+  },
+  data() {
+    return {};
+  },
+};
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
Missing `<template>` tag on the `/admin-dashboard` route was causing the Cloudflare Pages build to fail.